### PR TITLE
Fix servicios page comment path

### DIFF
--- a/app/servicios/page.tsx
+++ b/app/servicios/page.tsx
@@ -1,4 +1,4 @@
-// app/serivicios/page.tsx
+// app/servicios/page.tsx
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";


### PR DESCRIPTION
## Summary
- fix typo in `app/servicios/page.tsx` file header comment

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f74f5305c832fbf2a5a4b824b42c0