### PR TITLE
Add admin dish catalog and menu creation

### DIFF
--- a/app/admin/dishes/DishTable.tsx
+++ b/app/admin/dishes/DishTable.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useState } from "react";
+import { DishGroup } from "@prisma/client";
+
+interface Dish {
+  id: string;
+  name: string;
+  group: DishGroup;
+}
+
+export default function DishTable({ dishes: initial }: { dishes: Dish[] }) {
+  const [dishes, setDishes] = useState(initial);
+  const [name, setName] = useState("");
+  const [group, setGroup] = useState<DishGroup>(DishGroup.BREAKFAST_MAIN);
+
+  const addDish = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch("/api/dishes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, group }),
+    });
+    if (res.ok) {
+      const newDish = await res.json();
+      setDishes([...dishes, newDish]);
+      setName("");
+      setGroup(DishGroup.BREAKFAST_MAIN);
+    } else {
+      alert("Error al guardar platillo");
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">Catálogo de Platillos</h1>
+      <form onSubmit={addDish} className="flex gap-2 mb-4">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2 flex-1"
+          placeholder="Nombre"
+        />
+        <select
+          value={group}
+          onChange={(e) => setGroup(e.target.value as DishGroup)}
+          className="border p-2"
+        >
+          {Object.values(DishGroup).map((g) => (
+            <option key={g} value={g}>
+              {g}
+            </option>
+          ))}
+        </select>
+        <button type="submit" className="bg-blue-500 text-white px-4 rounded">
+          Agregar
+        </button>
+      </form>
+      <table className="w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 border">Nombre</th>
+            <th className="p-2 border">Grupo</th>
+          </tr>
+        </thead>
+        <tbody>
+          {dishes.map((d) => (
+            <tr key={d.id}>
+              <td className="border p-2">{d.name}</td>
+              <td className="border p-2">{d.group}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/admin/dishes/page.tsx
+++ b/app/admin/dishes/page.tsx
@@ -1,0 +1,18 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+import DishTable from "./DishTable";
+
+export default async function AdminDishesPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "ADMIN") {
+    redirect("/auth/signin");
+  }
+
+  const dishes = await prisma.dishCatalog.findMany({
+    orderBy: { name: "asc" },
+  });
+
+  return <DishTable dishes={dishes} />;
+}

--- a/app/admin/menus/MenuForm.tsx
+++ b/app/admin/menus/MenuForm.tsx
@@ -1,0 +1,192 @@
+"use client";
+import { useState } from "react";
+import { DishGroup, WeekDay } from "@prisma/client";
+
+interface Dish { id: string; name: string; group: DishGroup; }
+interface User { id: string; email: string; name: string | null; }
+interface DayData {
+  breakfast1: string;
+  breakfast2: string;
+  lunch1: string;
+  lunch2: string;
+  complement1: string;
+  complement2: string;
+  consume: string;
+  dessert: string;
+}
+
+const dayNames: Record<WeekDay, string> = {
+  MON: "Lunes",
+  TUE: "Martes",
+  WED: "Miércoles",
+  THU: "Jueves",
+  FRI: "Viernes",
+};
+const days: WeekDay[] = ["MON", "TUE", "WED", "THU", "FRI"];
+
+export default function MenuForm({ users, dishes }: { users: User[]; dishes: Dish[] }) {
+  const [author, setAuthor] = useState(users[0]?.id ?? "");
+  const [week, setWeek] = useState(1);
+  const [year, setYear] = useState(new Date().getFullYear());
+
+  const emptyDay: DayData = {
+    breakfast1: "",
+    breakfast2: "",
+    lunch1: "",
+    lunch2: "",
+    complement1: "",
+    complement2: "",
+    consume: "",
+    dessert: "",
+  };
+  const [menu, setMenu] = useState<Record<WeekDay, DayData>>({
+    MON: { ...emptyDay },
+    TUE: { ...emptyDay },
+    WED: { ...emptyDay },
+    THU: { ...emptyDay },
+    FRI: { ...emptyDay },
+  });
+
+  const handleChange = (day: WeekDay, field: string, value: string) => {
+    setMenu((m) => ({ ...m, [day]: { ...m[day], [field]: value } }));
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload = {
+      authorId: author,
+      week: Number(week),
+      year: Number(year),
+      days: days.map((d) => ({
+        day: d,
+        dishes: [
+          menu[d].breakfast1 && { name: getName(menu[d].breakfast1), group: "BREAKFAST_MAIN", position: 1 },
+          menu[d].breakfast2 && { name: getName(menu[d].breakfast2), group: "BREAKFAST_MAIN", position: 2 },
+          menu[d].lunch1 && { name: getName(menu[d].lunch1), group: "LUNCH_MAIN", position: 1 },
+          menu[d].lunch2 && { name: getName(menu[d].lunch2), group: "LUNCH_MAIN", position: 2 },
+          menu[d].complement1 && { name: getName(menu[d].complement1), group: "COMPLEMENT" },
+          menu[d].complement2 && { name: getName(menu[d].complement2), group: "COMPLEMENT" },
+          menu[d].consume && { name: getName(menu[d].consume), group: "CONSUME" },
+          menu[d].dessert && { name: getName(menu[d].dessert), group: "DESSERT" },
+        ].filter(Boolean),
+      })),
+    };
+    const res = await fetch("/api/menus", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) {
+      alert("Menú guardado");
+    } else {
+      alert("Error al guardar menú");
+    }
+  };
+
+  const getName = (id: string) => dishes.find((d) => d.id === id)?.name || "";
+  const options = (group: DishGroup) =>
+    dishes.filter((d) => d.group === group);
+
+  return (
+    <form onSubmit={submit} className="space-y-4 max-w-full p-4">
+      <div className="flex gap-2">
+        <select value={author} onChange={(e) => setAuthor(e.target.value)} className="border p-2">
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>
+              {u.email}
+            </option>
+          ))}
+        </select>
+        <input type="number" value={week} onChange={(e) => setWeek(parseInt(e.target.value))} className="border p-2 w-20" placeholder="Semana" />
+        <input type="number" value={year} onChange={(e) => setYear(parseInt(e.target.value))} className="border p-2 w-24" placeholder="Año" />
+        <button type="submit" className="bg-blue-500 text-white px-4 rounded">Guardar</button>
+      </div>
+      <table className="border w-full text-sm">
+        <thead>
+          <tr>
+            <th className="border p-2">Día</th>
+            <th className="border p-2">Desayuno 1</th>
+            <th className="border p-2">Desayuno 2</th>
+            <th className="border p-2">Comida 1</th>
+            <th className="border p-2">Comida 2</th>
+            <th className="border p-2">Compl. 1</th>
+            <th className="border p-2">Compl. 2</th>
+            <th className="border p-2">Consomé</th>
+            <th className="border p-2">Postre</th>
+          </tr>
+        </thead>
+        <tbody>
+          {days.map((d) => (
+            <tr key={d}>
+              <td className="border p-2 font-semibold">{dayNames[d]}</td>
+              <td className="border p-1">
+                <select value={menu[d].breakfast1} onChange={(e) => handleChange(d, "breakfast1", e.target.value)} className="w-full">
+                  <option value="">-</option>
+                  {options("BREAKFAST_MAIN").map((dish) => (
+                    <option key={dish.id} value={dish.id}>{dish.name}</option>
+                  ))}
+                </select>
+              </td>
+              <td className="border p-1">
+                <select value={menu[d].breakfast2} onChange={(e) => handleChange(d, "breakfast2", e.target.value)} className="w-full">
+                  <option value="">-</option>
+                  {options("BREAKFAST_MAIN").map((dish) => (
+                    <option key={dish.id} value={dish.id}>{dish.name}</option>
+                  ))}
+                </select>
+              </td>
+              <td className="border p-1">
+                <select value={menu[d].lunch1} onChange={(e) => handleChange(d, "lunch1", e.target.value)} className="w-full">
+                  <option value="">-</option>
+                  {options("LUNCH_MAIN").map((dish) => (
+                    <option key={dish.id} value={dish.id}>{dish.name}</option>
+                  ))}
+                </select>
+              </td>
+              <td className="border p-1">
+                <select value={menu[d].lunch2} onChange={(e) => handleChange(d, "lunch2", e.target.value)} className="w-full">
+                  <option value="">-</option>
+                  {options("LUNCH_MAIN").map((dish) => (
+                    <option key={dish.id} value={dish.id}>{dish.name}</option>
+                  ))}
+                </select>
+              </td>
+              <td className="border p-1">
+                <select value={menu[d].complement1} onChange={(e) => handleChange(d, "complement1", e.target.value)} className="w-full">
+                  <option value="">-</option>
+                  {options("COMPLEMENT").map((dish) => (
+                    <option key={dish.id} value={dish.id}>{dish.name}</option>
+                  ))}
+                </select>
+              </td>
+              <td className="border p-1">
+                <select value={menu[d].complement2} onChange={(e) => handleChange(d, "complement2", e.target.value)} className="w-full">
+                  <option value="">-</option>
+                  {options("COMPLEMENT").map((dish) => (
+                    <option key={dish.id} value={dish.id}>{dish.name}</option>
+                  ))}
+                </select>
+              </td>
+              <td className="border p-1">
+                <select value={menu[d].consume} onChange={(e) => handleChange(d, "consume", e.target.value)} className="w-full">
+                  <option value="">-</option>
+                  {options("CONSUME").map((dish) => (
+                    <option key={dish.id} value={dish.id}>{dish.name}</option>
+                  ))}
+                </select>
+              </td>
+              <td className="border p-1">
+                <select value={menu[d].dessert} onChange={(e) => handleChange(d, "dessert", e.target.value)} className="w-full">
+                  <option value="">-</option>
+                  {options("DESSERT").map((dish) => (
+                    <option key={dish.id} value={dish.id}>{dish.name}</option>
+                  ))}
+                </select>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </form>
+  );
+}

--- a/app/admin/menus/page.tsx
+++ b/app/admin/menus/page.tsx
@@ -1,0 +1,21 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+import MenuForm from "./MenuForm";
+
+export default async function AdminMenusPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "ADMIN") {
+    redirect("/auth/signin");
+  }
+
+  const users = await prisma.user.findMany({
+    orderBy: { email: "asc" },
+  });
+  const dishes = await prisma.dishCatalog.findMany({
+    orderBy: { name: "asc" },
+  });
+
+  return <MenuForm users={users} dishes={dishes} />;
+}

--- a/app/api/dishes/route.ts
+++ b/app/api/dishes/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { DishGroup } from "@prisma/client";
+
+export async function GET() {
+  const dishes = await prisma.dishCatalog.findMany({
+    orderBy: { name: "asc" },
+  });
+  return NextResponse.json(dishes);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { name, group } = await req.json();
+  if (!name || !group) {
+    return NextResponse.json({ error: "Missing data" }, { status: 400 });
+  }
+  const dish = await prisma.dishCatalog.create({
+    data: {
+      name,
+      group: group as DishGroup,
+    },
+  });
+  return NextResponse.json(dish, { status: 201 });
+}

--- a/app/api/menus/route.ts
+++ b/app/api/menus/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { DishGroup, WeekDay } from "@prisma/client";
+
+type NewMenu = {
+  authorId: string;
+  week: number;
+  year: number;
+  days: {
+    day: WeekDay;
+    dishes: {
+      name: string;
+      group: DishGroup;
+      position?: number | null;
+    }[];
+  }[];
+};
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const data = (await req.json()) as NewMenu;
+  const { authorId, week, year, days } = data;
+
+  const menu = await prisma.menu.create({
+    data: {
+      week,
+      year,
+      authorId,
+      days: {
+        create: days.map((day) => ({
+          day: day.day,
+          dishes: {
+            create: day.dishes.map((d) => ({
+              name: d.name,
+              group: d.group,
+              position: d.position ?? null,
+            })),
+          },
+        })),
+      },
+    },
+  });
+
+  return NextResponse.json(menu, { status: 201 });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,3 +66,9 @@ model Dish {
   dayMenuId String
   dayMenu   DayMenu   @relation(fields: [dayMenuId], references: [id])
 }
+
+model DishCatalog {
+  id    String    @id @default(cuid())
+  name  String
+  group DishGroup
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -23,7 +23,22 @@ console.log("URL:", process.env.DATABASE_URL);
     },
   });
 
-  // ── 2. Menú de la semana 19-2025 con sólo Lunes de ejemplo ───────────
+  // ── 2. Catalogo básico de platillos ─────────────
+  await prisma.dishCatalog.createMany({
+    data: [
+      { name: "Huevos Rancheros", group: DishGroup.BREAKFAST_MAIN },
+      { name: "Chilaquiles Verdes", group: DishGroup.BREAKFAST_MAIN },
+      { name: "Milanesa de Pollo", group: DishGroup.LUNCH_MAIN },
+      { name: "Carne en su Jugo", group: DishGroup.LUNCH_MAIN },
+      { name: "Frijoles Refritos", group: DishGroup.COMPLEMENT },
+      { name: "Arroz Rojo", group: DishGroup.COMPLEMENT },
+      { name: "Consomé de Pollo", group: DishGroup.CONSUME },
+      { name: "Gelatina de Fresa", group: DishGroup.DESSERT },
+    ],
+    skipDuplicates: true,
+  });
+
+  // ── 3. Menú de la semana 19-2025 con sólo Lunes de ejemplo ───────────
   await prisma.menu.create({
     data: {
       week: 19,


### PR DESCRIPTION
## Summary
- extend Prisma schema with `DishCatalog`
- seed a default catalog of dishes
- API to manage catalog dishes
- UI to manage dishes (admin only)
- API to create weekly menus from catalog
- form to create menus (admin only)

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_683f6c9db998832f8dc32bee30deef08