### PR TITLE
Fix session role checks and update NextAuth imports

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,5 +1,5 @@
 // app/admin/users/page.tsx
-import { getServerSession } from "next-auth";
+import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
@@ -7,7 +7,7 @@ import UserTable from "./UserTable";
 
 export default async function AdminUserPage() {
   const session = await getServerSession(authOptions);
-  if (!session || session.user.role !== "ADMIN") {
+  if (!session || session.user?.role !== "ADMIN") {
     redirect("/auth/signin");
   }
 

--- a/app/auth/[...nextauth]/route.ts
+++ b/app/auth/[...nextauth]/route.ts
@@ -1,5 +1,6 @@
-// src/app/auth/[...nextauth]/route.ts
-import { handlers } from "@/lib/auth";
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
 
-// Exponemos GET y POST para todas las sub-rutas de /auth/*
-export const { GET, POST } = handlers;
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,5 +1,5 @@
 // app/auth/signup/page.tsx
-import { getServerSession } from "next-auth";
+import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import SignUpForm from "./SignUpForm";
@@ -7,7 +7,7 @@ import SignUpForm from "./SignUpForm";
 export default async function SignUpPage() {
   const session = await getServerSession(authOptions);
 
-  if (!session || session.user.role !== "ADMIN") {
+  if (!session || session.user?.role !== "ADMIN") {
     redirect("/auth/signin");
   }
 

--- a/app/empleo/page.tsx
+++ b/app/empleo/page.tsx
@@ -1,5 +1,5 @@
 // app/empleo/page.tsx
-import { getServerSession } from "next-auth";
+import { getServerSession } from "next-auth/next";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from "react";
 import Providers from "@/components/Providers";
 import Navbar from "@/components/Navbar";
 import Link from "next/link";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import LogoutButton from "@/components/LogoutButton";
 

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -1,5 +1,5 @@
 // app/menu/page.tsx
-import { getServerSession } from "next-auth";
+import { getServerSession } from "next-auth/next";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";

--- a/app/servicios/page.tsx
+++ b/app/servicios/page.tsx
@@ -1,5 +1,5 @@
 // app/serivicios/page.tsx
-import { getServerSession } from "next-auth";
+import { getServerSession } from "next-auth/next";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,9 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: DefaultSession["user"] & {
+      role?: string;
+    };
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 // app/menu/page.tsx
-import { getServerSession } from "next-auth";
+import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";


### PR DESCRIPTION
## Summary
- import `getServerSession` from `next-auth/next`
- handle optional `session.user` when checking admin role
- update `[...nextauth]` route to use `authOptions`
- add a `next-auth.d.ts` typing file for user roles

## Testing
- `npm run build` *(fails: Property 'user' does not exist on type '{}')*

------
https://chatgpt.com/codex/tasks/task_e_686476164054832f9a2abc75b87fc71b